### PR TITLE
Look for .env file in the caller directory first

### DIFF
--- a/runregistry/runregistry.py
+++ b/runregistry/runregistry.py
@@ -10,7 +10,9 @@ from runregistry.utils import (
     __parse_runs_arg,
 )
 
-load_dotenv()
+# Look for .env file in the directory of the caller
+# first.
+load_dotenv(dotenv_path=os.path.join(os.getcwd(), ".env"))
 
 
 # Silence unverified HTTPS warning:

--- a/runregistry/runregistry.py
+++ b/runregistry/runregistry.py
@@ -11,8 +11,11 @@ from runregistry.utils import (
 )
 
 # Look for .env file in the directory of the caller
-# first.
-load_dotenv(dotenv_path=os.path.join(os.getcwd(), ".env"))
+# first. If it exists, use it.
+if os.path.exists(os.path.join(os.getcwd(), ".env")):
+    load_dotenv(dotenv_path=os.path.join(os.getcwd(), ".env"))
+else:
+    load_dotenv()
 
 
 # Silence unverified HTTPS warning:


### PR DESCRIPTION
This should fix some cases where the virtual environment used in NOT in the caller directory, but is somewhere else (e.g. `~/.virtualenvs`). 

Using `load_dotenv` without a path leads the `python-dotenv` package to look for `.env` in the directory hierarchy where the `runregistry` package is installed (in this example: `~/.virtualenvs`). 

We would, however, expect the `.env` file to be in the directory where the script using `runregistry` is. 