### PR TITLE
feat: add function to get datasets accepted from rr api

### DIFF
--- a/runregistry/runregistry.py
+++ b/runregistry/runregistry.py
@@ -619,3 +619,14 @@ def change_run_class(run_numbers, new_class):
             'Invalid input for "run_numbers". Please provide a list of numbers.'
         )
     return answers
+
+
+def get_datasets_accepted():
+    """
+    Method for fetching current datasets accepted in Offline Run Registry
+    """
+    url = "{}/datasets_accepted".format(api_url)
+    headers = _get_headers(token=_get_token())
+    if os.getenv("ENVIRONMENT") in ["development", "local"]:
+        print(url)
+    return requests.get(url, headers=headers).json()


### PR DESCRIPTION
This PR adds a very simple function to fetch the `datasets_accepted` endpoint. The function can be tested with the following snippet:

```python
import runregistry as rr

datasets = rr.get_datasets_accepted()
```