### PR TITLE
Make all methods' return values uniform

### DIFF
--- a/.github/workflows/test_package.yaml
+++ b/.github/workflows/test_package.yaml
@@ -34,4 +34,8 @@ jobs:
           SSO_CLIENT_SECRET: ${{ secrets.SSO_CLIENT_SECRET }}
           ENVIRONMENT: ${{ vars.ENVIRONMENT }}
         run: |
-          pytest tests --retries 2
+          pytest tests --cov=runregistry --cov-report xml --retries 2
+      - name: Upload results to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test_package.yaml
+++ b/.github/workflows/test_package.yaml
@@ -11,6 +11,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 ![Build Status](https://github.com/cms-DQM/runregistry_api_client/actions/workflows/test_package.yaml/badge.svg)
+[![codecov](https://codecov.io/github/cms-DQM/runregistry_api_client/graph/badge.svg?token=IRADJ57684)](https://codecov.io/github/cms-DQM/runregistry_api_client)
+[![PyPI version](https://badge.fury.io/py/runregistry.png)](https://badge.fury.io/py/runregistry)
 
 # Run Registry Client
 
@@ -389,17 +391,17 @@ generated_json = runregistry.create_json(json_logic=json_logic, dataset_name_fil
 You can also manipulate runs via API:
 
 1. Mark run significant:
-    ```python
-    runregistry.make_significant_runs(run=362761)
-    ```
+   ```python
+   runregistry.make_significant_runs(run=362761)
+   ```
 2. Reset RR attributes and reload data from OMS:
-    ```python
-    runregistry.reset_RR_attributes_and_refresh_runs(run=362761)
-    ```
+   ```python
+   runregistry.reset_RR_attributes_and_refresh_runs(run=362761)
+   ```
 3. Move runs from one state to another:
-    ```python
-    runregistry.move_runs("OPEN", "SIGNOFF", run=362761)
-    ```
+   ```python
+   runregistry.move_runs("OPEN", "SIGNOFF", run=362761)
+   ```
 
 ## Troubleshooting
 
@@ -414,6 +416,7 @@ python3 -m pip install --upgrade pip build twine
 python3 -m build
 python3 -m twine upload --skip-existing --repository pypi dist/*
 ```
+
 Instructions from [here](https://packaging.python.org/en/latest/tutorials/packaging-projects/).
 
 ## Running the tests
@@ -451,11 +454,11 @@ No.
 
 ### Should I be using `runregistry_api_client` for getting OMS data?
 
-No*.
+No\*.
 
 Our recommendation is to query Run Registry only for data that RR is responsible for.
 
-<small>*It's not that you can't, it's just that this puts extra burden on the application, making it slow for everyone.</small>
+<small>\*It's not that you can't, it's just that this puts extra burden on the application, making it slow for everyone.</small>
 
 ### Is the token stored somewhere and reused?
 

--- a/runregistry/runregistry.py
+++ b/runregistry/runregistry.py
@@ -615,7 +615,7 @@ def change_run_class(run_numbers, new_class):
         )
 
     if not isinstance(new_class, str):
-        raise Exception(f'Invalid input "{new_class}" for "new_class"')
+        raise ValueError(f'Invalid input "{new_class}" for "new_class"')
     answers = []
     # If just one int provided, make it into a list
     if isinstance(run_numbers, int):
@@ -624,7 +624,7 @@ def change_run_class(run_numbers, new_class):
     if isinstance(run_numbers, list):
         for run_number in run_numbers:
             if not isinstance(run_number, int):
-                raise Exception(
+                raise ValueError(
                     "Invalid run number value found in run_numbers. Please provide a list of numbers."
                 )
             answer = _execute_request_for_single_run(run_number, new_class)
@@ -634,7 +634,7 @@ def change_run_class(run_numbers, new_class):
                 )
             answers.append(answer.json())
     else:
-        raise Exception(
+        raise ValueError(
             'Invalid input for "run_numbers". Please provide a list of numbers.'
         )
     return answers

--- a/tests/test_advanced_rr_operations.py
+++ b/tests/test_advanced_rr_operations.py
@@ -48,6 +48,16 @@ def test_advanced_move_datasets_bad_from(setup_runregistry):
         )
 
 
+def test_advanced_move_datasets_no_run(setup_runregistry):
+    with pytest.raises(ValueError):
+        answers = runregistry.move_datasets(
+            from_="MPAMIES",
+            to_="SIGNOFF",
+            dataset_name=VALID_DATASET_NAME,
+            workspace="global",
+        )
+
+
 def test_advanced_move_datasets_bad_to(setup_runregistry):
     with pytest.raises(ValueError):
         answers = runregistry.move_datasets(
@@ -108,7 +118,7 @@ def test_advanced_reset_RR_attributes_and_refresh_runs_open(setup_runregistry):
 def test_advanced_manually_refresh_components_statuses_for_no_runs(setup_runregistry):
     with pytest.raises(ValueError):
         # Missing argument
-        answers = runregistry.manually_refresh_components_statuses_for_runs()
+        runregistry.manually_refresh_components_statuses_for_runs()
 
 
 def test_advanced_manually_refresh_components_statuses_for_runs_open(setup_runregistry):
@@ -124,9 +134,7 @@ def test_advanced_manually_refresh_components_statuses_for_runs_signed_off(
     setup_runregistry,
 ):
     with pytest.raises(Exception) as e:
-        answers = runregistry.manually_refresh_components_statuses_for_runs(
-            runs=VALID_RUN_NUMBER
-        )
+        runregistry.manually_refresh_components_statuses_for_runs(runs=VALID_RUN_NUMBER)
     assert "Run must be in state OPEN" in e.exconly()
 
 
@@ -139,27 +147,27 @@ def test_advanced_move_runs_no_run_arg(setup_runregistry):
 def test_advanced_move_single_run(setup_runregistry):
     with pytest.raises(Exception) as e:
         # Requires permission
-        answer = runregistry.move_runs("OPEN", "SIGNOFF", run=VALID_RUN_NUMBER)
+        runregistry.move_runs("OPEN", "SIGNOFF", run=VALID_RUN_NUMBER)
     assert "User needs to be part of any of the following e-groups" in e.exconly()
 
 
 def test_advanced_move_multi_runs(setup_runregistry):
     with pytest.raises(Exception) as e:
         # Requires permission
-        answers = runregistry.move_runs("OPEN", "SIGNOFF", runs=[VALID_RUN_NUMBER])
+        runregistry.move_runs("OPEN", "SIGNOFF", runs=[VALID_RUN_NUMBER])
     assert EGROUPS_ERROR in e.exconly()
 
 
 def test_advanced_move_runs_invalid(setup_runregistry):
     with pytest.raises(ValueError):
         # Requires permission
-        answers = runregistry.move_runs("!!!!", "???", runs=[VALID_RUN_NUMBER])
+        runregistry.move_runs("!!!!", "???", runs=[VALID_RUN_NUMBER])
 
 
 def test_advanced_edit_rr_lumisections_good(setup_runregistry):
     with pytest.raises(Exception) as e:
         # Requires permission
-        answer = runregistry.edit_rr_lumisections(
+        runregistry.edit_rr_lumisections(
             VALID_RUN_NUMBER, 0, 1, "castor-castor", "GOOD"
         )
     assert "User needs to be part of any of the following e-groups" in e.exconly()
@@ -168,6 +176,39 @@ def test_advanced_edit_rr_lumisections_good(setup_runregistry):
 def test_advanced_edit_rr_lumisections_bad(setup_runregistry):
     with pytest.raises(ValueError):
         # Requires permission
-        answer = runregistry.edit_rr_lumisections(
+        runregistry.edit_rr_lumisections(
             VALID_RUN_NUMBER, 0, 1, "castor-castor", "KALHSPERA STHN PAREA ;)"
         )
+
+
+def test_advanced_change_run_class_list(setup_runregistry):
+    with pytest.raises(Exception) as e:
+        # Requires permission
+        runregistry.change_run_class(run_numbers=[VALID_RUN_NUMBER], new_class="test")
+    assert "User needs to be part of any of the following e-groups" in e.exconly()
+
+
+def test_advanced_change_run_class_int(setup_runregistry):
+    """
+    Current behavior is to accept both a list and an int as run_numbers
+    """
+    with pytest.raises(Exception) as e:
+        # Still Requires permission
+        runregistry.change_run_class(run_numbers=VALID_RUN_NUMBER, new_class="test")
+    assert "User needs to be part of any of the following e-groups" in e.exconly()
+
+
+def test_advanced_change_run_class_list_with_bad_run_types(setup_runregistry):
+    with pytest.raises(ValueError) as e:
+        runregistry.change_run_class(run_numbers=["3455555"], new_class="test")
+
+
+def test_advanced_change_run_class_bad_run_numbers(setup_runregistry):
+    with pytest.raises(ValueError):
+        runregistry.change_run_class(run_numbers="3455555", new_class="test")
+
+
+def test_advanced_change_run_class_bad_new_class_type(setup_runregistry):
+    with pytest.raises(ValueError):
+        # Requires permission
+        runregistry.change_run_class(run_numbers=[VALID_RUN_NUMBER], new_class=1)

--- a/tests/test_advanced_rr_operations.py
+++ b/tests/test_advanced_rr_operations.py
@@ -5,6 +5,7 @@ import runregistry
 logger = logging.getLogger(__name__)
 VALID_RUN_NUMBER = 362874
 VALID_DATASET_NAME = "/PromptReco/Commissioning2021/DQM"
+EGROUPS_ERROR = "User needs to be part of any of the following e-groups"
 
 
 @pytest.fixture
@@ -13,110 +14,160 @@ def setup_runregistry():
     runregistry.setup("development")
 
 
-def test_move_datasets(setup_runregistry):
-    answers = runregistry.move_datasets(
-        from_=runregistry.WAITING_DQM_GUI_CONSTANT,
-        to_="OPEN",
-        dataset_name=VALID_DATASET_NAME,
-        run=VALID_RUN_NUMBER,
-        workspace="global",
-    )
+def test_advanced_move_datasets(setup_runregistry):
+    with pytest.raises(Exception) as e:
+        answers = runregistry.move_datasets(
+            from_=runregistry.WAITING_DQM_GUI_CONSTANT,
+            to_="OPEN",
+            dataset_name=VALID_DATASET_NAME,
+            run=VALID_RUN_NUMBER,
+            workspace="global",
+        )
+    assert EGROUPS_ERROR in e.exconly()
     # TODO: Run also with a token that has permission
-    assert all([answer.status_code == 401 for answer in answers])
-    answers = runregistry.move_datasets(
-        from_="OPEN",
-        to_="SIGNOFF",
-        dataset_name=VALID_DATASET_NAME,
-        run=VALID_RUN_NUMBER,
-        workspace="ctpps",
-    )
-    # Requires permission
-    assert all([answer.status_code == 401 for answer in answers])
+    with pytest.raises(Exception) as e:
+        # Requires permission
+        answers = runregistry.move_datasets(
+            from_="OPEN",
+            to_="SIGNOFF",
+            dataset_name=VALID_DATASET_NAME,
+            run=VALID_RUN_NUMBER,
+            workspace="ctpps",
+        )
+    assert EGROUPS_ERROR in e.exconly()
 
 
-def test_make_significant_single_run(setup_runregistry):
+def test_advanced_move_datasets_bad_from(setup_runregistry):
+    with pytest.raises(ValueError):
+        answers = runregistry.move_datasets(
+            from_="MPAMIES",
+            to_="SIGNOFF",
+            dataset_name=VALID_DATASET_NAME,
+            run=VALID_RUN_NUMBER,
+            workspace="global",
+        )
+
+
+def test_advanced_move_datasets_bad_to(setup_runregistry):
+    with pytest.raises(ValueError):
+        answers = runregistry.move_datasets(
+            from_=runregistry.WAITING_DQM_GUI_CONSTANT,
+            to_="AGKINARES",
+            dataset_name=VALID_DATASET_NAME,
+            run=VALID_RUN_NUMBER,
+            workspace="global",
+        )
+
+
+def test_advanced_make_significant_single_run(setup_runregistry):
     # Get latest run in dev runregistry and make it significant
     run = runregistry.get_runs(limit=1, filter={})[0]
-    answer = runregistry.make_significant_runs(run=run["run_number"])
-    # requires permission
-    assert answer.status_code == 401
+    with pytest.raises(Exception) as e:
+        # requires permission
+        runregistry.make_significant_runs(run=run["run_number"])
+    assert EGROUPS_ERROR in e.exconly()
 
 
-def test_make_significant_multi_runs(setup_runregistry):
+def test_advanced_make_significant_multi_runs(setup_runregistry):
     # Get latest run in dev runregistry and make it significant
     run = runregistry.get_runs(limit=1, filter={})[0]
-    answers = runregistry.make_significant_runs(runs=[run["run_number"]])
-    # requires permission
-    assert all([answer.status_code == 401 for answer in answers])
+    with pytest.raises(Exception) as e:
+        # requires permission
+        runregistry.make_significant_runs(runs=[run["run_number"]])
+    assert EGROUPS_ERROR in e.exconly()
 
 
-def test_reset_RR_attributes_and_refresh_runs_signed_off(setup_runregistry):
-    answers = runregistry.reset_RR_attributes_and_refresh_runs(runs=VALID_RUN_NUMBER)
-    # Cannot refresh runs which are not open
-    assert all(
-        [
-            answer.status_code == 500 and "Run must be in state OPEN" in answer.text
-            for answer in answers
-        ]
-    )
-
-
-def test_manually_refresh_components_statuses_for_runs_open(setup_runregistry):
+def test_advanced_make_significant_no_runs(setup_runregistry):
     run = runregistry.get_runs(limit=1, filter={})[0]
+    with pytest.raises(ValueError):
+        # Required args missing
+        runregistry.make_significant_runs()
+
+
+def test_advanced_reset_RR_attributes_and_refresh_runs_signed_off(setup_runregistry):
+    with pytest.raises(Exception) as e:
+        # Cannot refresh runs which are not open
+        answers = runregistry.reset_RR_attributes_and_refresh_runs(
+            runs=VALID_RUN_NUMBER
+        )
+    assert "Run must be in state OPEN" in repr(e)
+
+
+def test_advanced_reset_RR_attributes_and_refresh_runs_no_run(setup_runregistry):
+    with pytest.raises(ValueError) as e:
+        # Cannot refresh runs which are not open
+        answers = runregistry.reset_RR_attributes_and_refresh_runs()
+
+
+def test_advanced_reset_RR_attributes_and_refresh_runs_open(setup_runregistry):
+    run = runregistry.get_runs(limit=1, filter={})[0]
+    answers = runregistry.reset_RR_attributes_and_refresh_runs(runs=run["run_number"])
+    assert isinstance(answers, list)
+
+
+def test_advanced_manually_refresh_components_statuses_for_no_runs(setup_runregistry):
+    with pytest.raises(ValueError):
+        # Missing argument
+        answers = runregistry.manually_refresh_components_statuses_for_runs()
+
+
+def test_advanced_manually_refresh_components_statuses_for_runs_open(setup_runregistry):
+    run = runregistry.get_runs(limit=1, filter={})[0]
+    # Currently, manual refresh does not need special permissions??
     answers = runregistry.manually_refresh_components_statuses_for_runs(
         runs=run["run_number"]
     )
-    assert all([answer.status_code == 200 for answer in answers])
+    assert isinstance(answers, list)
 
 
-def test_reset_RR_attributes_and_refresh_runs_open(setup_runregistry):
-    run = runregistry.get_runs(limit=1, filter={})[0]
-    answers = runregistry.reset_RR_attributes_and_refresh_runs(runs=run["run_number"])
-    assert all([answer.status_code == 200 for answer in answers])
+def test_advanced_manually_refresh_components_statuses_for_runs_signed_off(
+    setup_runregistry,
+):
+    with pytest.raises(Exception) as e:
+        answers = runregistry.manually_refresh_components_statuses_for_runs(
+            runs=VALID_RUN_NUMBER
+        )
+    assert "Run must be in state OPEN" in e.exconly()
 
 
-def test_manually_refresh_components_statuses_for_runs_signed_off(setup_runregistry):
-    answers = runregistry.manually_refresh_components_statuses_for_runs(
-        runs=VALID_RUN_NUMBER
-    )
-    # Cannot refresh runs which are not open
-    assert all(
-        [
-            answer.status_code == 500 and "Run must be in state OPEN" in answer.text
-            for answer in answers
-        ]
-    )
-
-
-def test_move_runs_no_run_arg(setup_runregistry):
+def test_advanced_move_runs_no_run_arg(setup_runregistry):
     with pytest.raises(ValueError):
         # Raises ValueError
         runregistry.move_runs("OPEN", "SIGNOFF")
 
 
-def test_move_single_run(setup_runregistry):
-    """
-    Unfortunately, this function was given a dual signature, and can return
-    both a single or a list of request responses.
-    """
-    answer = runregistry.move_runs("OPEN", "SIGNOFF", run=VALID_RUN_NUMBER)
-    # Requires permission
-    assert answer.status_code == 401
+def test_advanced_move_single_run(setup_runregistry):
+    with pytest.raises(Exception) as e:
+        # Requires permission
+        answer = runregistry.move_runs("OPEN", "SIGNOFF", run=VALID_RUN_NUMBER)
+    assert "User needs to be part of any of the following e-groups" in e.exconly()
 
 
-def test_move_multi_runs(setup_runregistry):
-    """
-    Unfortunately, this function was given a dual signature, and can return
-    both a single or a list of request responses.
-    """
-    answers = runregistry.move_runs("OPEN", "SIGNOFF", runs=[VALID_RUN_NUMBER])
-    # Requires permission
-    assert all([answer.status_code == 401 for answer in answers])
+def test_advanced_move_multi_runs(setup_runregistry):
+    with pytest.raises(Exception) as e:
+        # Requires permission
+        answers = runregistry.move_runs("OPEN", "SIGNOFF", runs=[VALID_RUN_NUMBER])
+    assert EGROUPS_ERROR in e.exconly()
 
 
-def test_edit_rr_lumisections(setup_runregistry):
-    answer = runregistry.edit_rr_lumisections(
-        VALID_RUN_NUMBER, 0, 1, "castor-castor", "GOOD"
-    )
-    # Requires permission
-    assert answer.status_code == 401
+def test_advanced_move_runs_invalid(setup_runregistry):
+    with pytest.raises(ValueError):
+        # Requires permission
+        answers = runregistry.move_runs("!!!!", "???", runs=[VALID_RUN_NUMBER])
+
+
+def test_advanced_edit_rr_lumisections_good(setup_runregistry):
+    with pytest.raises(Exception) as e:
+        # Requires permission
+        answer = runregistry.edit_rr_lumisections(
+            VALID_RUN_NUMBER, 0, 1, "castor-castor", "GOOD"
+        )
+    assert "User needs to be part of any of the following e-groups" in e.exconly()
+
+
+def test_advanced_edit_rr_lumisections_bad(setup_runregistry):
+    with pytest.raises(ValueError):
+        # Requires permission
+        answer = runregistry.edit_rr_lumisections(
+            VALID_RUN_NUMBER, 0, 1, "castor-castor", "KALHSPERA STHN PAREA ;)"
+        )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,6 @@
 import json
-import warnings
-
+import pytest
+import runregistry
 from runregistry.runregistry import (
     get_run,
     get_runs,
@@ -12,7 +12,9 @@ from runregistry.runregistry import (
     get_lumisection_ranges,
     get_oms_lumisection_ranges,
     get_joint_lumisection_ranges,
-    generate_json,
+    get_cycles,
+    get_lumisection_ranges_by_component,
+    get_datasets_accepted,
     create_json,
     setup,
 )
@@ -26,7 +28,7 @@ VALID_DATASET_NAME = "/PromptReco/HICosmics18A/DQM"
 INVALID_DATASET_NAME = "/PromptKikiriko/HELLOCosmics18Z/DQM"
 
 
-def test_get_run():
+def test_client_get_run():
     run_number = VALID_RUN_NUMBER
     run = get_run(run_number=VALID_RUN_NUMBER)
     assert run["run_number"] == VALID_RUN_NUMBER
@@ -36,7 +38,13 @@ def test_get_run():
     assert not run
 
 
-def test_get_runs():
+def test_client_get_runs_no_filter():
+    with pytest.raises(Exception) as e:
+        runs = get_runs()
+    assert "must pass a filter" in e.exconly()
+
+
+def test_client_get_runs():
     # Gets runs between run number VALID_RUN_RANGE_START and VALID_RUN_RANGE_STOP
     filter_run = {
         "run_number": {
@@ -69,7 +77,7 @@ def test_get_runs():
     assert len(runs) > 0
 
 
-def test_get_runs_with_ignore_filter():
+def test_client_get_runs_with_ignore_filter():
     filter_run = {
         "run_number": {
             "and": [{">": VALID_RUN_RANGE_START}, {"<": VALID_RUN_RANGE_STOP}]
@@ -81,7 +89,7 @@ def test_get_runs_with_ignore_filter():
     assert len(runs) > 0
 
 
-def test_get_datasets_with_ignore_filter():
+def test_client_get_datasets_with_ignore_filter():
     # datasets = get_datasets(filter={
     #     "run_number": {
     #         "and": [{
@@ -121,12 +129,12 @@ def test_get_datasets_with_ignore_filter():
     assert len(datasets) > 0
 
 
-# test_get_datasets_with_ignore_filter()
+# test_client_get_datasets_with_ignore_filter()
 
-# test_get_runs_with_ignore_filter()
+# test_client_get_runs_with_ignore_filter()
 
 
-def test_get_runs_not_compressed():
+def test_client_get_runs_not_compressed():
     runs = get_runs(
         filter={
             "run_number": {
@@ -156,12 +164,12 @@ def get_runs_with_combined_filter():
     assert len(runs) > 0
 
 
-def test_get_dataset_names_of_run():
+def test_client_get_dataset_names_of_run():
     dataset_names = get_dataset_names_of_run(run_number=VALID_RUN_NUMBER)
     assert len(dataset_names) > 0
 
 
-def test_get_dataset():
+def test_client_get_dataset():
     dataset = get_dataset(run_number=VALID_RUN_NUMBER, dataset_name=VALID_DATASET_NAME)
     assert dataset["run_number"] == VALID_RUN_NUMBER
     assert dataset["name"] == VALID_DATASET_NAME
@@ -171,54 +179,87 @@ def test_get_dataset():
     assert not dataset
 
 
-def test_get_datasets():
+def test_client_get_datasets_no_limit():
     datasets = get_datasets(
+        compress_attributes=True,
         filter={
             "run_number": {
                 "and": [{">": VALID_RUN_RANGE_START}, {"<": VALID_RUN_RANGE_STOP}]
             }
-        }
+        },
+    )
+    assert len(datasets) > 0
+    assert "Run" not in datasets[0]
+
+
+def test_client_get_datasets_no_compression():
+    datasets = get_datasets(
+        compress_attributes=False,
+        filter={
+            "run_number": {
+                "and": [{">": VALID_RUN_RANGE_START}, {"<": VALID_RUN_RANGE_STOP}]
+            }
+        },
+    )
+    assert len(datasets) > 0
+    assert "Run" in datasets[0]
+
+
+def test_client_get_datasets_with_limit():
+    datasets = get_datasets(
+        limit=5,
+        filter={
+            "run_number": {
+                "and": [{">": VALID_RUN_RANGE_START}, {"<": VALID_RUN_RANGE_STOP}]
+            }
+        },
     )
     assert len(datasets) > 0
 
 
-def test_get_lumisections():
+def test_client_get_datasets_no_filters():
+    with pytest.raises(Exception) as e:
+        datasets = get_datasets()
+    assert "must pass a filter" in e.exconly()
+
+
+def test_client_get_lumisections():
     lumisections = get_lumisections(VALID_RUN_NUMBER, VALID_DATASET_NAME)
     assert len(lumisections) > 0
 
 
-def test_get_oms_lumisections():
+def test_client_get_oms_lumisections():
     lumisections = get_oms_lumisections(VALID_RUN_NUMBER)
     assert len(lumisections) > 0
     dataset_lumisections = get_oms_lumisections(VALID_RUN_NUMBER, VALID_DATASET_NAME)
     assert len(dataset_lumisections) > 0
 
 
-def test_get_lumisection_ranges():
+def test_client_get_lumisection_ranges():
     lumisections = get_lumisection_ranges(VALID_RUN_NUMBER, VALID_DATASET_NAME)
     assert len(lumisections) > 0
 
 
-def test_get_oms_lumisection_ranges():
+def test_client_get_oms_lumisection_ranges():
     lumisections = get_oms_lumisection_ranges(VALID_RUN_NUMBER)
     assert len(lumisections) > 0
 
 
-def test_get_joint_lumisection_ranges():
+def test_client_get_joint_lumisection_ranges():
     lumisections = get_joint_lumisection_ranges(VALID_RUN_NUMBER, VALID_DATASET_NAME)
     assert len(lumisections) > 0
 
 
-def test_get_collisions18():
+def test_client_get_collisions18():
     runs = get_runs(filter={"class": "Collisions18"})
     assert len(runs) > 0
 
 
-def test_get_or_run():
+def test_client_get_or_run():
     runs = get_runs(filter={"run_number": {"or": [VALID_RUN_NUMBER]}})
 
 
-def test_get_datasets_with_filter():
+def test_client_get_datasets_with_filter():
     datasets = get_datasets(
         filter={
             "run_number": {
@@ -229,143 +270,6 @@ def test_get_datasets_with_filter():
     )
     assert len(datasets) > 0
 
-
-def test_generate_json():
-    # https://docs.python.org/3/library/warnings.html#testing-warnings
-    with warnings.catch_warnings(record=True) as w:
-        warnings.simplefilter("always")
-        generate_json(
-            """
-{
-    "and": [
-        {
-            "or": [
-                {
-                    "==": [
-                        {
-                            "var": "dataset.name"
-                        },
-                        "/PromptReco/Collisions2018A/DQM"
-                    ]
-                }
-            ]
-        }
-    ]
-}
-        """
-        )
-        assert len(w) == 1
-        assert issubclass(w[-1].category, PendingDeprecationWarning)
-        assert "deprecated" in str(w[-1].message)
-
-
-# UNSAFE:
-# def test_generate_json():
-#     json_logic = """
-#         {
-#         "and": [
-#             {
-#                 "or": [
-#                     {"==": [{"var": "dataset.name"}, "/PromptReco/Collisions2018A/DQM"]},
-#                     {"==": [{"var": "dataset.name"}, "/PromptReco/Collisions2018B/DQM"]},
-#                     {"==": [{"var": "dataset.name"}, "/PromptReco/Collisions2018C/DQM"]},
-#                     {"==": [{"var": "dataset.name"}, "/PromptReco/Collisions2018D/DQM"]},
-#                     {"==": [{"var": "dataset.name"}, "/PromptReco/Collisions2018E/DQM"]},
-#                     {"==": [{"var": "dataset.name"}, "/PromptReco/Collisions2018F/DQM"]},
-#                     {"==": [{"var": "dataset.name"}, "/PromptReco/Collisions2018G/DQM"]},
-#                     {"==": [{"var": "dataset.name"}, "/PromptReco/Collisions2018H/DQM"]},
-#                     {"==": [{"var": "dataset.name"}, "/PromptReco/Collisions2018I/DQM"]}
-#                 ]
-#             },
-#             { ">=": [{ "var": "run.oms.energy" }, 6000] },
-#             { "<=": [{ "var": "run.oms.energy" }, 7000] },
-#             { ">=": [{ "var": "run.oms.b_field" }, 3.7] },
-#             { "in": [ "25ns", { "var": "run.oms.injection_scheme" }] },
-#             { "==": [{ "in": [ "WMass", { "var": "run.oms.hlt_key" }] }, false] },
-
-#             { "==": [{ "var": "lumisection.rr.dt-dt" }, "GOOD"] },
-#             { "==": [{ "var": "lumisection.rr.csc-csc" }, "GOOD"] },
-#             { "==": [{ "var": "lumisection.rr.l1t-l1tmu" }, "GOOD"] },
-#             { "==": [{ "var": "lumisection.rr.l1t-l1tcalo" }, "GOOD"] },
-#             { "==": [{ "var": "lumisection.rr.hlt-hlt" }, "GOOD"] },
-#             { "==": [{ "var": "lumisection.rr.tracker-pixel" }, "GOOD"] },
-#             { "==": [{ "var": "lumisection.rr.tracker-strip" }, "GOOD"] },
-#             { "==": [{ "var": "lumisection.rr.tracker-track" }, "GOOD"] },
-#             { "==": [{ "var": "lumisection.rr.ecal-ecal" }, "GOOD"] },
-#             { "==": [{ "var": "lumisection.rr.ecal-es" }, "GOOD"] },
-#             { "==": [{ "var": "lumisection.rr.hcal-hcal" }, "GOOD"] },
-#             { "==": [{ "var": "lumisection.rr.muon-muon" }, "GOOD"] },
-#             { "==": [{ "var": "lumisection.rr.jetmet-jetmet" }, "GOOD"] },
-#             { "==": [{ "var": "lumisection.rr.lumi-lumi" }, "GOOD"] },
-#             { "==": [{ "var": "lumisection.rr.dc-lowlumi" }, "BAD"] },
-
-#             { "==": [{ "var": "lumisection.oms.cms_active" }, true] },
-#             { "==": [{ "var": "lumisection.oms.bpix_ready" }, true] },
-#             { "==": [{ "var": "lumisection.oms.fpix_ready" }, true] },
-#             { "==": [{ "var": "lumisection.oms.tibtid_ready" }, true] },
-#             { "==": [{ "var": "lumisection.oms.tecm_ready" }, true] },
-#             { "==": [{ "var": "lumisection.oms.tecp_ready" }, true] },
-#             { "==": [{ "var": "lumisection.oms.tob_ready" }, true] },
-#             { "==": [{ "var": "lumisection.oms.ebm_ready" }, true] },
-#             { "==": [{ "var": "lumisection.oms.ebp_ready" }, true] },
-#             { "==": [{ "var": "lumisection.oms.eem_ready" }, true] },
-#             { "==": [{ "var": "lumisection.oms.eep_ready" }, true] },
-#             { "==": [{ "var": "lumisection.oms.esm_ready" }, true] },
-#             { "==": [{ "var": "lumisection.oms.esp_ready" }, true] },
-#             { "==": [{ "var": "lumisection.oms.hbhea_ready" }, true] },
-#             { "==": [{ "var": "lumisection.oms.hbheb_ready" }, true] },
-#             { "==": [{ "var": "lumisection.oms.hbhec_ready" }, true] },
-#             { "==": [{ "var": "lumisection.oms.hf_ready" }, true] },
-#             { "==": [{ "var": "lumisection.oms.ho_ready" }, true] },
-#             { "==": [{ "var": "lumisection.oms.dtm_ready" }, true] },
-#             { "==": [{ "var": "lumisection.oms.dtp_ready" }, true] },
-#             { "==": [{ "var": "lumisection.oms.dt0_ready" }, true] },
-#             { "==": [{ "var": "lumisection.oms.cscm_ready" }, true] },
-#             { "==": [{ "var": "lumisection.oms.cscp_ready" }, true] },
-#             { "==": [{ "var": "lumisection.oms.rpc_ready" }, true] },
-#             { "==": [{ "var": "lumisection.oms.beam1_present" }, true] },
-#             { "==": [{ "var": "lumisection.oms.beam2_present" }, true] },
-#             { "==": [{ "var": "lumisection.oms.beam1_stable" }, true] },
-#             { "==": [{ "var": "lumisection.oms.beam2_stable" }, true] }
-#         ]
-#     }
-#     """
-#     UNSAFE:
-#     final_json = generate_json(json_logic)
-#     assert final_json is not None
-#     json_logic2 = {
-#         "and": [
-#             {
-#                 "or": [
-#                     {"==": [{"var": "dataset.name"}, "/PromptReco/Collisions2018A/DQM"]},
-#                     {"==": [{"var": "dataset.name"}, "/PromptReco/Collisions2018B/DQM"]},
-#                     {"==": [{"var": "dataset.name"}, "/PromptReco/Collisions2018C/DQM"]},
-#                     {"==": [{"var": "dataset.name"}, "/PromptReco/Collisions2018D/DQM"]},
-#                     {"==": [{"var": "dataset.name"}, "/PromptReco/Collisions2018E/DQM"]},
-#                     {"==": [{"var": "dataset.name"}, "/PromptReco/Collisions2018F/DQM"]},
-#                     {"==": [{"var": "dataset.name"}, "/PromptReco/Collisions2018G/DQM"]},
-#                     {"==": [{"var": "dataset.name"}, "/PromptReco/Collisions2018H/DQM"]},
-#                     {"==": [{"var": "dataset.name"}, "/PromptReco/Collisions2018I/DQM"]}
-#                 ]
-#             },
-#             { ">=": [{ "var": "run.oms.energy" }, 6000] },
-#             { "<=": [{ "var": "run.oms.energy" }, 7000] },
-#             { ">=": [{ "var": "run.oms.b_field" }, 3.7] },
-#             { "in": [ "25ns", { "var": "run.oms.injection_scheme" }] },
-#             { "==": [{ "in": [ "WMass", { "var": "run.oms.hlt_key" }] }, False] },
-
-#             { "==": [{ "var": "lumisection.rr.dt-dt" }, "GOOD"] },
-#             { "==": [{ "var": "lumisection.rr.csc-csc" }, "GOOD"] },
-#             { "==": [{ "var": "lumisection.rr.l1t-l1tmu" }, "GOOD"] },
-#             { "==": [{ "var": "lumisection.rr.l1t-l1tcalo" }, "GOOD"] },
-#             { "==": [{ "var": "lumisection.rr.hlt-hlt" }, "GOOD"] },
-
-#             { "==": [{ "var": "lumisection.oms.bpix_ready" }, True] }
-#         ]
-#     }
-#     final_json2 = generate_json(json_logic2)
-
-#     assert final_json2 is not None
 
 json_logic = {
     "and": [
@@ -384,14 +288,14 @@ json_logic = {
 }
 
 
-def test_create_json():
+def test_client_create_json():
     json = create_json(
         json_logic=json_logic, dataset_name_filter="/PromptReco/Collisions2018A/DQM"
     )
     print(json)
 
 
-def test_custom_filter():
+def test_client_custom_filter():
     filter_arg = {
         "dataset_name": {"like": "%/PromptReco/Cosmics18CRUZET%"},
         "run_number": {
@@ -404,3 +308,47 @@ def test_custom_filter():
 
     datasets = get_datasets(filter=filter_arg)
     assert datasets
+
+
+def test_client_setup_random():
+    with pytest.raises(Exception) as e:
+        setup("Olo kaskarikes mas kaneis")
+    assert "Invalid setup target" in e.exconly()
+
+
+def test_client_setup_production():
+    setup("production")
+    assert "https://cmsrunregistry" in runregistry.runregistry.api_url
+
+
+def test_client_setup_development():
+    setup("development")
+    assert "https://dev-cmsrunregistry" in runregistry.runregistry.api_url
+
+
+def test_client_get_cycles():
+    answers = get_cycles()
+    assert len(answers) > 0
+    assert "id_cycle" in answers[0]
+    assert "cycle_name" in answers[0]
+    assert "cycle_attributes" in answers[0]
+    assert "deadline" in answers[0]
+    assert "datasets" in answers[0]
+
+
+def test_client_get_lumisection_ranges_by_component():
+    answer = get_lumisection_ranges_by_component(VALID_RUN_NUMBER)
+    assert len(answer.keys()) > 0
+    assert "dt-dt" in answer
+    assert "rpc-hv" in answer
+    assert "tracker-track_private" in answer
+
+
+def test_client_get_datasets_accepted():
+    answers = get_datasets_accepted()
+    assert len(answers) > 0
+    assert isinstance(answers[0], dict)
+    assert "regexp" in answers[0]
+    assert "id" in answers[0]
+    assert "name" in answers[0]
+    assert "class" in answers[0]


### PR DESCRIPTION
- [Breaking change] Basically all `runregistry` methods, instead of returning `request.Response`, will now try to parse them, run json() and return a dict, or list of dicts. Exceptions are now raised in case of insufficient permissions. Previously, the return values were different for each method, others being `request.Response` (or lists of those), `dict`s, or lists of `dict`s.
- Added codecov for test coverage.
- Added several tests for extending test coverage.
