### PR TITLE
fix: re-expose `__version__` in package root

### DIFF
--- a/runregistry/__init__.py
+++ b/runregistry/__init__.py
@@ -1,1 +1,2 @@
+from .runregistry import __version__
 from .runregistry import *


### PR DESCRIPTION
This commit simply re-expose the `__version__` variable in the package root to avoid a breaking change.

## Breaking change introduced in `3.1.0-0`

Users might programmatically fetch the package version using `runregistry.__version__`. From `3.1.0-0` users would have to access the version using `runregistry.runregistry.__version__`.

## Test

### Before

```
>>> import runregistry
>>>
>>> runregistry.__version__
Traceback (most recent call last):
File "<stdin>", line 1, in <module>
AttributeError: module 'runregistry' has no attribute '__version__'
>>>
>>> runregistry.runregistry.__version__
'3.1.0-0'
```

### After

```
>>> import runregistry
>>> runregistry.__version__
'3.1.0-0'
>>> runregistry.runregistry.__version__
'3.1.0-0'
```