### PR TITLE
[Backport] Add User-Agent to requests +

### DIFF
--- a/.github/workflows/test_package.yaml
+++ b/.github/workflows/test_package.yaml
@@ -7,10 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
@@ -34,4 +36,8 @@ jobs:
           SSO_CLIENT_SECRET: ${{ secrets.SSO_CLIENT_SECRET }}
           ENVIRONMENT: ${{ vars.ENVIRONMENT }}
         run: |
-          pytest tests -s
+          pytest tests --cov=runregistry --cov-report xml --retries 2
+      - name: Upload results to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/runregistry/__init__.py
+++ b/runregistry/__init__.py
@@ -1,5 +1,1 @@
 from .runregistry import *
-
-# To update:
-# pip install wheel && pip install twine && python setup.py bdist_wheel && twine upload --skip-existing dist/*
-__version__ = "1.4.1"

--- a/runregistry/__init__.py
+++ b/runregistry/__init__.py
@@ -1,1 +1,2 @@
+from .runregistry import __version__
 from .runregistry import *

--- a/runregistry/runregistry.py
+++ b/runregistry/runregistry.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import time
 import json
 import requests
@@ -9,6 +10,8 @@ from runregistry.utils import (
     transform_to_rr_dataset_filter,
     __parse_runs_arg,
 )
+
+__version__ = "1.4.1"
 
 # Look for .env file in the directory of the caller
 # first. If it exists, use it.
@@ -32,12 +35,15 @@ use_cookies = True
 email = "api@api"
 client_id = os.environ.get("SSO_CLIENT_ID")
 client_secret = os.environ.get("SSO_CLIENT_SECRET")
+target_application = ""
+target_name = ""
 
 
 def setup(target):
     global api_url
     global target_application
     global use_cookies
+    global target_name
 
     if target == "local":
         api_url = "http://localhost:9500"
@@ -46,15 +52,17 @@ def setup(target):
     elif target == "development":
         api_url = "https://dev-cmsrunregistry.web.cern.ch/api"
         use_cookies = True
-        target_application = "webframeworks-paas-dev-cmsrunregistry"
-    # elif target == "qa":
-    #     api_url = "https://cmsrunregistry-qa.web.cern.ch/api"  # Temporary new SSO Proxy for production
-    #     use_cookies = True
-    #     target_application = "webframeworks-paas-qa-cmsrunregistry"
+        target_application = "dev-cmsrunregistry-sso-proxy"
     elif target == "production":
         api_url = "https://cmsrunregistry.web.cern.ch/api"
         use_cookies = True
-        target_application = "webframeworks-paas-cmsrunregistry"
+        target_application = "cmsrunregistry-sso-proxy"
+
+    target_name = target
+
+
+def _get_user_agent():
+    return f"runregistry_api_client/{__version__} ({_get_target()}, python {sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}, requests {requests.__version__})"
 
 
 def _get_headers(token: str = ""):
@@ -63,10 +71,15 @@ def _get_headers(token: str = ""):
         headers["email"] = email
     if token:
         headers["Authorization"] = "Bearer " + token
+    headers["User-Agent"] = _get_user_agent()
     return headers
 
 
 setup(os.environ.get("ENVIRONMENT", "production"))
+
+
+def _get_target():
+    return target_name
 
 
 def _get_token():
@@ -76,8 +89,8 @@ def _get_token():
     Gets the token required to query RR API through the CERN SSO.
     :return: the token required to query Run Registry API. In particular 'connect.sid' is the one we are interested in
     """
-    # if os.getenv("ENVIRONMENT") == "development":
-    #     return None
+    if _get_target() == "local":
+        return ""
     token, expiration_date = get_api_token(
         client_id=client_id,
         client_secret=client_secret,
@@ -100,7 +113,7 @@ def _get_page(
         query_filter = transform_to_rr_run_filter(run_filter=query_filter)
     elif data_type == "datasets" and not ignore_filter_transformation:
         query_filter = transform_to_rr_dataset_filter(dataset_filter=query_filter)
-    if os.getenv("ENVIRONMENT") == "development":
+    if _get_target() in ["development", "local"]:
         print(url)
         print(query_filter)
     payload = json.dumps(
@@ -259,7 +272,7 @@ def get_datasets(limit=40000, compress_attributes=True, **kwargs) -> list:
 def get_cycles():
     url = "{}/cycles/global".format(api_url)
     headers = _get_headers(token=_get_token())
-    if os.getenv("ENVIRONMENT") == "development":
+    if _get_target() in ["development", "local"]:
         print(url)
     return requests.get(url, headers=headers).json()
 

--- a/runregistry/runregistry.py
+++ b/runregistry/runregistry.py
@@ -3,7 +3,7 @@ import time
 import json
 import requests
 from dotenv import load_dotenv
-from cernrequests import get_api_token, get_with_token
+from cernrequests import get_api_token
 from runregistry.utils import (
     transform_to_rr_run_filter,
     transform_to_rr_dataset_filter,
@@ -121,7 +121,7 @@ def get_dataset_names_of_run(run_number, **kwargs):
     :return: Array of dataset names of the specified run_number
     """
     url = "{}/get_all_dataset_names_of_run/{}".format(api_url, run_number)
-    return get_with_token(url, target_application=target_application).json()
+    return requests.get(url, headers=_get_headers(token=_get_token())).json()
 
 
 def get_run(run_number, **kwargs):

--- a/runregistry/runregistry.py
+++ b/runregistry/runregistry.py
@@ -11,7 +11,7 @@ from runregistry.utils import (
     __parse_runs_arg,
 )
 
-__version__ = "1.4.1"
+__version__ = "1.5.0"
 
 # Look for .env file in the directory of the caller
 # first. If it exists, use it.

--- a/runregistry/utils.py
+++ b/runregistry/utils.py
@@ -24,6 +24,8 @@ def __parse_runs_arg(runs):
             return []
     elif isinstance(runs, list):
         return runs
+    else:
+        return []
 
 
 def transform_to_rr_run_filter(run_filter):
@@ -32,7 +34,7 @@ def transform_to_rr_run_filter(run_filter):
     :param run_filter: a filter that the user inputs into the api client
     :return: returns a filter that runregistry back end understands.
     """
-    if not run_filter:
+    if not run_filter or not isinstance(run_filter, dict):
         return {}
     transformed_filter = {}
     for key, value in run_filter.items():
@@ -91,7 +93,7 @@ def transform_to_rr_dataset_filter(dataset_filter):
     :param dataset_filter: a filter that the user inputs into the api client
     :return: returns a filter that runregistry back end understands.
     """
-    if not dataset_filter:
+    if not dataset_filter or not isinstance(dataset_filter, dict):
         return {}
     transformed_filter = {}
     for key, value in dataset_filter.items():

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ with open(os.path.join(here, "README.md")) as f:
 
 setup(
     name="runregistry",
-    version=find_version("runregistry", "__init__.py"),
+    version=find_version("runregistry", "runregistry.py"),
     packages=find_packages(),
     author="Fabio Espinosa",
     description="CMS Run Registry client",

--- a/testing-requirements.txt
+++ b/testing-requirements.txt
@@ -1,4 +1,5 @@
 pytest>=3.6
+pytest-retry
 pytest-cov
 codecov
 -e .

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,12 +1,91 @@
-from runregistry.utils import transform_to_rr_run_filter
+import sys
+import pytest
+import requests
+from runregistry.utils import (
+    transform_to_rr_run_filter,
+    transform_to_rr_dataset_filter,
+    dataset_triplet_attributes,
+    run_rr_attributes,
+)
+from runregistry.attributes import (
+    run_oms_attributes,
+    run_triplet_attributes,
+    dataset_attributes,
+)
+from runregistry.runregistry import (
+    __version__,
+    _get_user_agent,
+    _get_headers,
+    _get_token,
+    _get_target,
+    __parse_runs_arg as _parse_runs_arg,
+    setup,
+)
 
 
-class TestFilterCreation:
+class TestRunRegistryFilterCreation:
     def test_get_run(self):
         run_number = 323434
         assert transform_to_rr_run_filter(run_filter={"run_number": run_number}) == {
             "run_number": {"=": run_number}
         }
+
+    def test_transform_triplets(self):
+        VALID_VALUES = ["GOOD", "BAD", "STANDBY", "EXCLUDED", "NOTSET", "EMPTY"]
+        for attribute in run_triplet_attributes:
+            for value in VALID_VALUES:
+                result = transform_to_rr_run_filter(
+                    run_filter={attribute: {"=": value}}
+                )
+                assert f"triplet_summary.{attribute}.{value}" in result
+        with pytest.raises(Exception):
+            transform_to_rr_run_filter(run_filter={"ecal-ecal": {"=": "HEHEHE"}})
+
+    def test_transform_invalid_attribute(self):
+        with pytest.raises(Exception):
+            transform_to_rr_run_filter(run_filter={"BRE KAKOS MPELAS": {"=": "HEHEHE"}})
+        assert not transform_to_rr_run_filter(None)
+        assert not transform_to_rr_run_filter("")
+        assert not transform_to_rr_run_filter("SDF")
+        assert not transform_to_rr_run_filter(15)
+
+    def test_transform_attributes(self):
+        VALID_ATTRIBUTES = [
+            "rr_attributes",
+            "oms_attributes",
+            "triplet_summary",
+            "triplet_summaryalksjdflkajsd",  # Unsure why this should be supported
+        ]
+        FILTER = {"=": "aaa"}
+        for attribute in VALID_ATTRIBUTES:
+            result = transform_to_rr_run_filter(run_filter={attribute: FILTER})
+            assert attribute in result and result[attribute] == FILTER
+
+    def test_transform_run_oms_attributes(self):
+
+        FILTER = {"=": "test"}
+        for attribute in run_oms_attributes:
+            if attribute == "run_number":
+                print(
+                    "run_number seems to exist on both run_oms_attributes and "
+                    + "run_triplet_attributes, meaning that run_number cannot "
+                    + "be used with run_oms_attributes, only triplets"
+                )
+                continue
+            result = transform_to_rr_run_filter(run_filter={attribute: FILTER})
+            assert (
+                f"oms_attributes.{attribute}" in result
+                and result[f"oms_attributes.{attribute}"] == FILTER
+            )
+
+    def test_transform_run_rr_attributes(self):
+        FILTER = {"=": "test"}
+        for attribute in run_rr_attributes:
+            result = transform_to_rr_run_filter(run_filter={attribute: FILTER})
+            assert (
+                f"rr_attributes.{attribute}" in result
+                and result[f"rr_attributes.{attribute}"] == FILTER
+            )
 
     def test_get_multiple_run_using_or(self):
         run_number1 = 323555
@@ -30,3 +109,125 @@ class TestFilterCreation:
         }
 
         assert transform_to_rr_run_filter(run_filter=user_input) == desired_output
+
+
+class TestDatasetFilterCreation:
+    def test_dataset_attributes(self):
+        FILTER = {"=": "aaa"}
+        for attribute in dataset_attributes:
+            result = transform_to_rr_dataset_filter(dataset_filter={attribute: FILTER})
+            assert (
+                f"dataset_attributes.{attribute}" in result
+                and result[f"dataset_attributes.{attribute}"] == FILTER
+            )
+
+    def test_dataset_triplet_attributes_valid(self):
+        VALID_VALUES = ["GOOD", "BAD", "STANDBY", "EXCLUDED", "NOTSET", "EMPTY"]
+        for value in VALID_VALUES:
+            for attribute in dataset_triplet_attributes:
+                result = transform_to_rr_dataset_filter(
+                    dataset_filter={attribute: {"=": value}}
+                )
+                assert f"triplet_summary.{attribute}.{value}" in result
+
+    def test_dataset_triplet_attributes_invalid(self):
+        with pytest.raises(Exception):
+            transform_to_rr_dataset_filter(
+                dataset_filter={dataset_triplet_attributes[0]: {"=": "ZE MALESI :("}}
+            )
+
+    def test_transform_run_oms_attributes(self):
+        FILTER = {"=": "test"}
+        for attribute in run_oms_attributes:
+            if attribute == "run_number":
+                print(
+                    "run_number seems to exist on both run_oms_attributes and "
+                    + "run_triplet_attributes, meaning that run_number cannot "
+                    + "be used with run_oms_attributes, only triplets"
+                )
+                continue
+            result = transform_to_rr_dataset_filter(dataset_filter={attribute: FILTER})
+            assert (
+                f"oms_attributes.{attribute}" in result
+                and result[f"oms_attributes.{attribute}"] == FILTER
+            )
+
+    def test_transform_run_rr_attributes(self):
+        FILTER = {"=": "test"}
+        for attribute in run_rr_attributes:
+            result = transform_to_rr_dataset_filter(dataset_filter={attribute: FILTER})
+            assert (
+                f"rr_attributes.{attribute}" in result
+                and result[f"rr_attributes.{attribute}"] == FILTER
+            )
+
+    def test_transform_invalid_attribute(self):
+        with pytest.raises(Exception):
+            transform_to_rr_dataset_filter(
+                dataset_filter={"BRE KAKOS MPELAS": {"=": "HEHEHE"}}
+            )
+        assert not transform_to_rr_dataset_filter(None)
+        assert not transform_to_rr_dataset_filter("")
+        assert not transform_to_rr_dataset_filter("SDF")
+        assert not transform_to_rr_dataset_filter(15)
+
+
+class TestUtils:
+    MAGIC_RUN = 255525
+
+    def test_user_agent(self):
+        ua = _get_user_agent()
+        assert (
+            __version__ in ua
+            and "runregistry_api_client" in ua
+            and f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+            in ua
+            and requests.__version__ in ua
+            and "zodiac sign" not in ua
+        )
+
+    def test_runregistry_setup(self):
+        for target in ["development", "local", "production"]:
+            setup(target)
+
+            assert _get_target() == target
+
+        # This it not compatible with v1
+        # and will not raise an exception of type Exception
+        # with pytest.raises(Exception):
+        #    setup("HAHAHAHA >:)")
+
+    def test_headers(self):
+        headers = _get_headers(token="WHATEVER :/")
+        assert all(
+            [key in headers for key in ["User-Agent", "Authorization", "Content-type"]]
+        )
+
+    def test_get_token(self):
+        setup("local")
+        assert _get_token() == ""
+
+    def test_parse_runs_int(self):
+        runs = _parse_runs_arg(self.MAGIC_RUN)
+        assert isinstance(runs, list) and runs[0] == self.MAGIC_RUN
+
+    def test_parse_runs_str_int(self):
+        runs = _parse_runs_arg(str(self.MAGIC_RUN))
+        assert isinstance(runs, list) and runs[0] == self.MAGIC_RUN
+
+    def test_parse_runs_str_str(self):
+        runs = _parse_runs_arg("LMAO ://////////")
+        assert isinstance(runs, list) and len(runs) == 0
+
+    def test_parse_runs_list_int(self):
+        runs = _parse_runs_arg([self.MAGIC_RUN, self.MAGIC_RUN + 1])
+        assert isinstance(runs, list) and len(runs) == 2
+
+    def test_parse_runs_list_str(self):
+        # This case should probably be fixed to only accept list of ints
+        runs = _parse_runs_arg([str(self.MAGIC_RUN), str(self.MAGIC_RUN + 1)])
+        assert isinstance(runs, list) and len(runs) == 2
+
+    def test_parse_runs_dict(self):
+        runs = _parse_runs_arg({self.MAGIC_RUN})
+        assert isinstance(runs, list) and len(runs) == 0


### PR DESCRIPTION
This PR backports #12, #13 and #14 that are needed for a transparent transition between the old `cern-auth-proxy` deployed via the helm chart and the new manually deployed `cern-auth-proxy`.

In order to test this PR, you need to update the `__version__` to `1.5.0` in `runregistry/runregistry.py`. The version will be officially bumped when this version gets released.

---

Also backports the commit [f4fa0db](https://github.com/cms-DQM/runregistry_api_client/commit/f4fa0db58edecfdf6afb0b9708eaf5bc0e37ed3b).